### PR TITLE
feat: run resume tailoring against local Ollama model

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A comprehensive Streamlit application that uses AI to tailor resumes to specific
 
 - **Resume Upload**: Support for .docx, .txt, and .pdf resume formats
 - **Job Description Analysis**: Intelligent parsing of job requirements and keywords
-- **AI-Powered Tailoring**: Uses OpenAI GPT models to rewrite experience bullets and generate relevant projects
+- **AI-Powered Tailoring**: Uses local open-source GPT models (via [Ollama](https://ollama.com)) to rewrite experience bullets and generate relevant projects
 - **Keyword Optimization**: Identifies missing keywords and suggests improvements for ATS systems
 - **Document Generation**: Creates downloadable Word documents with tailored content
 - **Multiple Input Methods**: Upload files or paste text directly
@@ -31,10 +31,10 @@ pip install -r requirements.txt
 python -m spacy download en_core_web_sm
 ```
 
-4. Set up environment variables:
+4. Install and run a local language model using [Ollama](https://ollama.com):
 ```bash
-cp .env.template .env
-# Edit .env and add your OpenAI API key
+curl -fsSL https://ollama.com/install.sh | sh
+ollama pull gpt-oss:20b
 ```
 
 ### Option 2: Using Setup.py
@@ -56,18 +56,14 @@ streamlit run streamlit_resume_tailor.py
 2. Open your browser to `http://localhost:8501`
 
 3. Follow the on-screen instructions:
-   - Enter your OpenAI API key in the sidebar
+   - Ensure your local model (e.g., `gpt-oss:20b`) is running via Ollama
    - Upload your resume (.docx or .txt format)
    - Upload job description or paste the text
    - Click "Tailor Resume" to generate optimized content
 
 ### Configuration
 
-Create a `.env` file with your OpenAI API key:
-```
-OPENAI_API_KEY=your_api_key_here
-OPENAI_MODEL=gpt-3.5-turbo
-```
+The application uses a local model served by Ollama. You can override the default model name by setting the `MODEL_NAME` environment variable.
 
 ## Project Structure
 
@@ -97,7 +93,7 @@ resume-tailoring-tool/
 - Identifies industry and job level context
 
 ### ResumeGenerator
-- Uses OpenAI GPT models for content generation
+- Uses local GPT models via Ollama for content generation
 - Tailors experience bullets to match job requirements
 - Generates relevant projects based on job context
 - Creates formatted Word documents for download
@@ -132,7 +128,7 @@ resume-tailoring-tool/
 2. Visit [share.streamlit.io](https://share.streamlit.io)
 3. Connect your GitHub repository
 4. Deploy with one click
-5. Add your OpenAI API key in Streamlit Cloud secrets
+5. Ensure the deployment environment can access the Ollama service and required model
 
 ### Other Platforms
 
@@ -183,10 +179,9 @@ def _extract_domain_specific_keywords(self, text):
    python -m spacy download en_core_web_sm
    ```
 
-2. **OpenAI API Errors**
-   - Verify your API key is correct
-   - Check your OpenAI account has sufficient credits
-   - Ensure you're using a supported model
+2. **Ollama Model Errors**
+   - Verify the Ollama service is running
+   - Ensure the requested model is installed (e.g., `ollama pull gpt-oss:20b`)
 
 3. **File Upload Issues**
    - Ensure files are in supported formats (.docx, .txt, .pdf)
@@ -216,7 +211,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 ## Acknowledgments
 
-- OpenAI for GPT models
+- Ollama and the open-source model community
 - spaCy and NLTK for natural language processing
 - Streamlit for the web framework
 - python-docx for Word document manipulation
@@ -237,4 +232,4 @@ For support, please open an issue on GitHub or contact [your-email@example.com].
 
 ---
 
-**Note**: This tool requires an OpenAI API key to function. Make sure to keep your API key secure and never commit it to version control.
+**Note**: This tool requires a locally running language model (e.g., via Ollama). Ensure the service is running and the appropriate model is installed.

--- a/keyword_extractor.py
+++ b/keyword_extractor.py
@@ -1,5 +1,4 @@
 
-import openai
 import re
 import spacy
 import nltk

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ streamlit==1.32.0
 python-docx==0.8.11
 PyPDF2==3.0.1
 pdfplumber==0.10.0
-openai==1.10.0
 spacy>=3.7.0
 nltk>=3.8
 python-dotenv==1.0.0
 fpdf2==2.7.8
+requests>=2.31.0

--- a/resume_generator.py
+++ b/resume_generator.py
@@ -1,6 +1,5 @@
 
-import openai
-import json
+import requests
 from docx import Document
 from docx.shared import Inches
 from docx.enum.text import WD_ALIGN_PARAGRAPH
@@ -11,22 +10,16 @@ import re
 class ResumeGenerator:
     """Generates tailored resume content and documents"""
 
-    def __init__(self):
-        self.openai_client = None
-        self.model_name = "gpt-3.5-turbo"
-
-    def set_openai_key(self, api_key: str):
-        """Set OpenAI API key"""
-        openai.api_key = api_key
-        self.openai_client = openai.OpenAI(api_key=api_key)
+    def __init__(self, base_url: str = "http://localhost:11434/api/generate", model_name: str = "gpt-oss:20b"):
+        self.base_url = base_url
+        self.model_name = model_name
 
     def tailor_resume(self, parsed_resume: Dict[str, Any],
-                     job_analysis: Dict[str, Any], api_key: str,
-                     model_name: str = "gpt-3.5-turbo") -> Dict[str, Any]:
+                     job_analysis: Dict[str, Any],
+                     model_name: str = "gpt-oss:20b") -> Dict[str, Any]:
         """Main function to tailor resume content"""
 
         self.model_name = model_name
-        self.set_openai_key(api_key)
 
         # Generate key themes analysis
         key_themes = self._generate_key_themes(job_analysis)
@@ -59,6 +52,17 @@ class ResumeGenerator:
             'docx_content': docx_content
         }
 
+    def _call_model(self, prompt: str) -> str:
+        """Call the local language model via HTTP."""
+        try:
+            payload = {"model": self.model_name, "prompt": prompt, "stream": False}
+            response = requests.post(self.base_url, json=payload, timeout=60)
+            response.raise_for_status()
+            data = response.json()
+            return data.get("response", "").strip()
+        except Exception as e:
+            return f"Error communicating with model: {e}"
+
     def _generate_key_themes(self, job_analysis: Dict[str, Any]) -> str:
         """Generate key themes analysis from job description"""
 
@@ -79,21 +83,10 @@ class ResumeGenerator:
         Provide a 2-3 sentence summary focusing on what makes this role unique.
         """
 
-        try:
-            response = self.openai_client.chat.completions.create(
-                model=self.model_name,
-                messages=[
-                    {"role": "system", "content": "You are an expert resume analyst who helps job seekers understand job requirements."},
-                    {"role": "user", "content": prompt}
-                ],
-                max_tokens=200,
-                temperature=0.7
-            )
+        system_prompt = "You are an expert resume analyst who helps job seekers understand job requirements."
+        full_prompt = f"{system_prompt}\n{prompt}"
 
-            return response.choices[0].message.content.strip()
-
-        except Exception as e:
-            return f"Error generating key themes: {str(e)}"
+        return self._call_model(full_prompt)
 
     def _tailor_experience_section(self, experiences: List[Dict[str, Any]], 
                                  job_analysis: Dict[str, Any]) -> str:
@@ -162,22 +155,17 @@ class ResumeGenerator:
         Provide 3-4 strong bullets that show you already have experience doing what this job requires:
         """
 
-        try:
-            response = self.openai_client.chat.completions.create(
-                model=self.model_name,
-                messages=[
-                    {"role": "system", "content": "You are an expert resume writer who specializes in tailoring experience bullets to match specific job requirements while maintaining truthfulness."},
-                    {"role": "user", "content": prompt}
-                ],
-                max_tokens=400,
-                temperature=0.8
-            )
+        system_prompt = (
+            "You are an expert resume writer who specializes in tailoring experience bullets "
+            "to match specific job requirements while maintaining truthfulness."
+        )
+        full_prompt = f"{system_prompt}\n{prompt}"
 
-            return response.choices[0].message.content.strip()
-
-        except Exception as e:
-            # Fallback to original bullets if API fails
+        result = self._call_model(full_prompt)
+        if result.startswith("Error"):
+            # Fallback to original bullets if model call fails
             return "\n".join(['• ' + bullet for bullet in original_bullets])
+        return result
 
     def _generate_tailored_projects(self, parsed_resume: Dict[str, Any], 
                                   job_analysis: Dict[str, Any]) -> str:
@@ -219,21 +207,13 @@ class ResumeGenerator:
         Generate 1-2 compelling projects:
         """
 
-        try:
-            response = self.openai_client.chat.completions.create(
-                model=self.model_name,
-                messages=[
-                    {"role": "system", "content": "You are an expert resume writer who creates realistic, relevant project descriptions that align with job requirements."},
-                    {"role": "user", "content": prompt}
-                ],
-                max_tokens=500,
-                temperature=0.8
-            )
+        system_prompt = (
+            "You are an expert resume writer who creates realistic, relevant project descriptions "
+            "that align with job requirements."
+        )
+        full_prompt = f"{system_prompt}\n{prompt}"
 
-            return response.choices[0].message.content.strip()
-
-        except Exception as e:
-            return f"Error generating projects: {str(e)}"
+        return self._call_model(full_prompt)
 
     def _extract_tools_from_text(self, text: str) -> List[str]:
         """Extract tools and technologies mentioned in resume text"""

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ setup(
         "python-docx>=0.8.11",
         "PyPDF2>=3.0.1",
         "pdfplumber>=0.10.0",
-        "openai>=1.10.0",
         "spacy>=3.7.0",
         "nltk>=3.8",
         "python-dotenv>=1.0.0",
-        "fpdf2>=2.7.8"
+        "fpdf2>=2.7.8",
+        "requests>=2.31.0"
     ],
     python_requires=">=3.8",
     author="Your Name",

--- a/streamlit_resume_tailor.py
+++ b/streamlit_resume_tailor.py
@@ -5,7 +5,6 @@ import json
 import io
 from datetime import datetime
 from dotenv import load_dotenv
-import openai
 from resume_parser import ResumeParser
 from resume_generator import ResumeGenerator
 from keyword_extractor import KeywordExtractor
@@ -19,14 +18,11 @@ class ResumeCustomizer:
         self.generator = ResumeGenerator()
         self.keyword_extractor = KeywordExtractor()
 
-    def process_resume_tailoring(self, resume_content, job_description, openai_key):
+    def process_resume_tailoring(self, resume_content, job_description, model_name):
         """Main processing function for resume tailoring"""
 
-        # Set OpenAI API key
-        openai.api_key = openai_key
-
-        # Get model from environment, with a fallback
-        model_name = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+        # Use model name from argument or environment
+        model_name = model_name or os.getenv("MODEL_NAME", "gpt-oss:20b")
 
         # Extract keywords and context from job description
         job_analysis = self.keyword_extractor.analyze_job_description(job_description)
@@ -38,7 +34,6 @@ class ResumeCustomizer:
         tailored_content = self.generator.tailor_resume(
             parsed_resume,
             job_analysis,
-            openai_key,
             model_name=model_name
         )
 
@@ -54,18 +49,21 @@ def main():
     st.title("🎯 AI-Powered Resume Tailoring Tool")
     st.markdown("Upload your resume and job description to get a perfectly tailored resume!")
 
-    # Sidebar for OpenAI API key
+    # Sidebar for model configuration
     with st.sidebar:
         st.header("Configuration")
-        openai_key = st.text_input("OpenAI API Key", type="password", 
-                                 help="Enter your OpenAI API key to enable AI features")
+        model_name = st.text_input(
+            "Model Name",
+            value="gpt-oss:20b",
+            help="Name of the local model served via Ollama"
+        )
 
         st.markdown("---")
         st.markdown("### Instructions")
         st.markdown("""
-        1. Upload your current resume (.docx or .txt)
-        2. Upload job description (.pdf, .txt) or paste text
-        3. Enter your OpenAI API key
+        1. Install and run [Ollama](https://ollama.com)
+        2. Pull the desired model, e.g. `ollama pull gpt-oss:20b`
+        3. Upload your resume and job description
         4. Click 'Tailor Resume' to generate optimized version
         """)
 
@@ -107,10 +105,6 @@ def main():
 
     # Processing section
     if st.button("🚀 Tailor Resume", type="primary", use_container_width=True):
-        if not openai_key:
-            st.error("Please provide your OpenAI API key in the sidebar")
-            return
-
         if not resume_file:
             st.error("Please upload your resume")
             return
@@ -126,7 +120,7 @@ def main():
 
                 # Process the tailoring
                 result = customizer.process_resume_tailoring(
-                    resume_file, job_description, openai_key
+                    resume_file, job_description, model_name
                 )
 
                 # Display results
@@ -166,7 +160,7 @@ def main():
 
             except Exception as e:
                 st.error(f"An error occurred: {str(e)}")
-                st.error("Please check your API key and try again")
+                st.error("Please ensure your local model is running and try again")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- remove OpenAI API key requirement and call a local Ollama model for text generation
- update Streamlit app to configure the model name and rely on a running Ollama service
- refresh docs and dependencies to reflect the local model setup

## Testing
- `python -m py_compile resume_generator.py streamlit_resume_tailor.py keyword_extractor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894ed8be37083308a5bce4fd1c1891a