### PR TITLE
Add punkt_tab tokenizer download for NLTK 3.8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ pip install -r requirements.txt
 python -m spacy download en_core_web_sm
 ```
 
+> The application will download required NLTK tokenizers (`punkt` and `punkt_tab` for NLTK 3.8+) at runtime if they are missing. Ensure internet access for the first execution.
+
 4. Install and run a local language model using [Ollama](https://ollama.com):
 ```bash
 curl -fsSL https://ollama.com/install.sh | sh

--- a/keyword_extractor.py
+++ b/keyword_extractor.py
@@ -12,6 +12,18 @@ try:
 except LookupError:
     nltk.download('punkt', quiet=True)
 
+# Download additional tokenizer tables introduced in newer NLTK versions
+try:
+    nltk_version = tuple(int(x) for x in nltk.__version__.split('.')[:2])
+except ValueError:
+    nltk_version = (0, 0)
+
+if nltk_version >= (3, 8):
+    try:
+        nltk.data.find('tokenizers/punkt_tab')
+    except LookupError:
+        nltk.download('punkt_tab', quiet=True)
+
 try:
     nltk.data.find('corpora/stopwords')
 except LookupError:


### PR DESCRIPTION
## Summary
- Ensure NLTK's newer `punkt_tab` tokenizer tables are available by downloading them when running with NLTK 3.8 or newer
- Document the automatic download of `punkt` and `punkt_tab` resources during installation

## Testing
- `pytest`
- `python -m py_compile keyword_extractor.py`


------
https://chatgpt.com/codex/tasks/task_e_6894fa88f2008330a5799709ec8e8400